### PR TITLE
add url-scheme-dependant auth

### DIFF
--- a/git/auth.go
+++ b/git/auth.go
@@ -2,6 +2,9 @@ package git
 
 import (
 	"context"
+	"sync"
+
+	giturls "github.com/whilp/git-urls"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -9,22 +12,57 @@ import (
 	"github.com/gov4git/lib4git/must"
 )
 
-var auth transport.AuthMethod
-
-func setAuth(a transport.AuthMethod) {
-	auth = a
+func MakePasswordAuth(ctx context.Context, user string, pass string) transport.AuthMethod {
+	return &http.BasicAuth{Username: user, Password: pass}
 }
 
-func SetPasswordAuth(ctx context.Context, user string, pass string) {
-	auth = &http.BasicAuth{Username: user, Password: pass}
+func MakeTokenAuth(ctx context.Context, token string) transport.AuthMethod {
+	return &http.BasicAuth{Username: "123", Password: token} // "123" can be anything but empty
 }
 
-func SetTokenAuth(ctx context.Context, token string) {
-	auth = &http.BasicAuth{Username: "123", Password: token} // "123" can be anything but empty
-}
-
-func SetSSHFileAuth(ctx context.Context, user string, privKeyFile string) {
+func MakeSSHFileAuth(ctx context.Context, user string, privKeyFile string) transport.AuthMethod {
 	pubKey, err := ssh.NewPublicKeysFromFile(user, privKeyFile, "")
 	must.NoError(ctx, err)
-	auth = pubKey
+	return pubKey
+}
+
+// repo-dependent auth
+
+var authManager AuthManager
+
+func GetAuth(ctx context.Context, forRepo URL) transport.AuthMethod {
+	return authManager.GetAuth(ctx, forRepo)
+}
+
+type AuthManager struct {
+	lk    sync.Mutex
+	ssh   transport.AuthMethod
+	https transport.AuthMethod
+}
+
+func (x *AuthManager) SetAuthHTTPS(a transport.AuthMethod) {
+	x.lk.Lock()
+	defer x.lk.Unlock()
+	x.https = a
+}
+
+func (x *AuthManager) SetAuthSSH(a transport.AuthMethod) {
+	x.lk.Lock()
+	defer x.lk.Unlock()
+	x.ssh = a
+}
+
+func (x *AuthManager) GetAuth(ctx context.Context, forRepo URL) transport.AuthMethod {
+	u, err := giturls.Parse(string(forRepo))
+	must.NoError(ctx, err)
+	x.lk.Lock()
+	defer x.lk.Unlock()
+	switch u.Scheme {
+	case "http", "https":
+		return x.https
+	case "ssh":
+		return x.ssh
+	default:
+		return nil
+	}
 }

--- a/git/auth_test.go
+++ b/git/auth_test.go
@@ -1,0 +1,22 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gov4git/lib4git/must"
+	giturls "github.com/whilp/git-urls"
+)
+
+func TestAuthURL(t *testing.T) {
+	ctx := context.Background()
+
+	u, err := giturls.Parse("git@github.com:petar/gov4git.public.git")
+	must.NoError(ctx, err)
+	fmt.Println(u)
+
+	u, err = giturls.Parse("/x/y/z")
+	must.NoError(ctx, err)
+	fmt.Println(u)
+}

--- a/git/git.go
+++ b/git/git.go
@@ -98,7 +98,7 @@ func CloneRepo(ctx context.Context, addr Address) *Repository {
 		memfs.New(),
 		&git.CloneOptions{
 			URL:           string(addr.Repo),
-			Auth:          auth, // TODO: extract from context
+			Auth:          GetAuth(ctx, addr.Repo), // TODO: extract from context
 			ReferenceName: plumbing.NewBranchReferenceName(string(addr.Branch)),
 			SingleBranch:  true,
 		},

--- a/git/sync.go
+++ b/git/sync.go
@@ -37,7 +37,7 @@ func PushRefSpecs(ctx context.Context, repo *Repository, to URL, refspecs []conf
 			Fetch: refspecs,
 		},
 	)
-	must.NoError(ctx, remote.PushContext(ctx, &git.PushOptions{RemoteName: nonce, Auth: auth}))
+	must.NoError(ctx, remote.PushContext(ctx, &git.PushOptions{RemoteName: nonce, Auth: GetAuth(ctx, to)}))
 }
 
 func PullRefSpecs(ctx context.Context, repo *Repository, from URL, refspecs []config.RefSpec) {
@@ -50,5 +50,5 @@ func PullRefSpecs(ctx context.Context, repo *Repository, from URL, refspecs []co
 			Fetch: refspecs,
 		},
 	)
-	must.NoError(ctx, remote.FetchContext(ctx, &git.FetchOptions{RemoteName: nonce, Auth: auth}))
+	must.NoError(ctx, remote.FetchContext(ctx, &git.FetchOptions{RemoteName: nonce, Auth: GetAuth(ctx, from)}))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gofrs/flock v0.8.1
+	github.com/whilp/git-urls v1.0.0
 	go.uber.org/zap v1.23.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=


### PR DESCRIPTION
Add an authentication method manager, which produces auth methods depending on the URL scheme of a git repo URL.