### PR TITLE
add JSON encoding for `git.Address`, add `IsNotExist` and `BytesHashToFilename`

### DIFF
--- a/form/bytes.go
+++ b/form/bytes.go
@@ -35,10 +35,14 @@ func DecodeBytesFromString(s string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(s)
 }
 
-func StringHashForFilename(s string) string {
+func BytesHashForFilename(s []byte) string {
 	h := sha256.New()
-	if _, err := h.Write([]byte(s)); err != nil {
+	if _, err := h.Write(s); err != nil {
 		panic(err)
 	}
 	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h.Sum(nil)))
+}
+
+func StringHashForFilename(s string) string {
+	return BytesHashForFilename([]byte(s))
 }

--- a/git/errors.go
+++ b/git/errors.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -71,4 +72,8 @@ func IsRefNotFound(err error) bool {
 
 func IsRepoIsInaccessible(err error) bool {
 	return IsAuthRequired(err) || IsIOTimeout(err) || IsRepoNotFound(err)
+}
+
+func IsNotExist(err error) bool {
+	return err == os.ErrNotExist
 }

--- a/git/git.go
+++ b/git/git.go
@@ -35,9 +35,10 @@ const MainBranch Branch = "main"
 
 const Origin = "origin"
 
+// Address points to a branch in a networked git repo.
 type Address struct {
-	Repo   URL
-	Branch Branch
+	Repo   URL    `json:"git_repo"`
+	Branch Branch `json:"git_branch"`
 }
 
 func (a Address) IsEmpty() bool {


### PR DESCRIPTION
- specify JSON encoding of `git.Address` structures
- add `IsNotExist` function to test if an error is caused by a missing file
- add a `[]byte`-flavored variant of `StringHashToFilename`

Needed by https://github.com/gov4git/gov4git/pull/62